### PR TITLE
 Add ResetToken model and migration

### DIFF
--- a/migrations/20240523144214-create-message-table.js
+++ b/migrations/20240523144214-create-message-table.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('message', {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true
+      },
+      sender_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      receiver_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      job_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      content: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      }
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('message');
+  }
+};

--- a/migrations/20240523162045-create-accessToken-table.js
+++ b/migrations/20240523162045-create-accessToken-table.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('access_token', {
+      id: {
+        type: Sequelize.UUID,
+        autoIncrement: true,
+        primaryKey: true
+      },
+
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'user',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+
+      is_revoked: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false
+      },
+
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+
+      expires_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      }
+    })
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('access_token');
+  }
+};

--- a/migrations/20240524083123-create-resetToken-table.js
+++ b/migrations/20240524083123-create-resetToken-table.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('reset_token', {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4
+      },
+
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'user',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+
+      is_revoked: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false
+      },
+
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+
+      expires_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      }
+    })
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('reset_token');
+  }
+};

--- a/migrations/20240524100453-create-refreshToken-table.js
+++ b/migrations/20240524100453-create-refreshToken-table.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('refresh_token', {
+      id: {
+        type: Sequelize.UUID,
+        autoIncrement: true,
+        primaryKey: true
+      },
+
+      access_token_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'access_token',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+
+      is_revoked: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false
+      },
+
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+
+      expires_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      }
+    })
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('refresh_token');
+  }
+};

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,8 @@ import { User } from 'modules/user/user.model';
 import { Worker } from 'modules/worker/worker.model';
 import { Job } from 'modules/job/job.model';
 import { Transaction } from 'modules/transaction/transaction.model';
+import { Message } from 'modules/message/message.model';
+import { AccessToken } from 'modules/auth/accessToken.model';
 
 
 @Module({
@@ -21,12 +23,12 @@ import { Transaction } from 'modules/transaction/transaction.model';
         username: configService.get<string>('DB_USERNAME'),
         password: configService.get<string>('DB_PASSWORD'),
         database: configService.get<string>('DB_NAME'),
-        models: [User, Worker, Job, Transaction],
+        models: [User, Worker, Job, Transaction, Message, AccessToken],
         autoLoadModels: true,
         synchronize: false,
       }),
     }),
-    SequelizeModule.forFeature([User, Worker, Job, Transaction]),
+    SequelizeModule.forFeature([User, Worker, Job, Transaction, Message, AccessToken]),
   ],
 })
 export class AppModule {}

--- a/src/modules/auth/accessToken.model.ts
+++ b/src/modules/auth/accessToken.model.ts
@@ -1,0 +1,52 @@
+import { UUID } from "crypto";
+import { Model, Column, DataType, ForeignKey, Table } from "sequelize-typescript";
+import { User } from "../user/user.model";
+
+@Table({ tableName: 'access_token' })
+export class AccessToken extends Model<AccessToken> {
+    @Column({
+        type: DataType.INTEGER,
+        autoIncrement: true,
+        primaryKey: true
+    })
+    id: UUID;
+
+    @ForeignKey(() => User)
+    @Column({
+        type: DataType.INTEGER,
+        allowNull: false,
+        field: 'user_id'
+    })
+    user_id: number;
+
+    @Column({
+        type: DataType.BOOLEAN,
+        allowNull: false,
+        field: 'is_revoked'
+    })
+    is_revoked: boolean;
+    
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'created_at'
+    })
+    created_at: Date;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'updated_at'
+    })
+    updated_at: Date;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'expires_at'
+    })
+    expires_at: Date;
+};

--- a/src/modules/auth/refreshToken.model.ts
+++ b/src/modules/auth/refreshToken.model.ts
@@ -1,0 +1,51 @@
+import { Model, Column, DataType, ForeignKey, Table } from "sequelize-typescript";
+import { AccessToken } from "./accessToken.model";
+
+@Table({ tableName: 'refresh_token' })
+export class RefreshToken extends Model<RefreshToken> {
+    @Column({
+        type: DataType.UUID,
+        primaryKey: true,
+        defaultValue: DataType.UUIDV4
+    })
+    id: string;
+
+    @ForeignKey(() => AccessToken)
+    @Column({
+        type: DataType.INTEGER,
+        allowNull: false,
+        field: 'access_token_id'
+    })
+    access_token_id: number;
+
+    @Column({
+        type: DataType.BOOLEAN,
+        allowNull: false,
+        field: 'is_revoked'
+    })
+    is_revoked: boolean;
+    
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'created_at'
+    })
+    created_at: Date;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'updated_at'
+    })
+    updated_at: Date;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'expires_at'
+    })
+    expires_at: Date;
+};

--- a/src/modules/auth/resetToken.model.ts
+++ b/src/modules/auth/resetToken.model.ts
@@ -1,0 +1,51 @@
+import { Model, Column, DataType, ForeignKey, Table } from "sequelize-typescript";
+import { User } from "../user/user.model";
+
+@Table({ tableName: 'reset_token' })
+export class ResetToken extends Model<ResetToken> {
+    @Column({
+        type: DataType.UUID,
+        primaryKey: true,
+        defaultValue: DataType.UUIDV4
+    })
+    id: string;
+
+    @ForeignKey(() => User)
+    @Column({
+        type: DataType.INTEGER,
+        allowNull: false,
+        field: 'user_id'
+    })
+    user_id: number;
+
+    @Column({
+        type: DataType.BOOLEAN,
+        allowNull: false,
+        field: 'is_revoked'
+    })
+    is_revoked: boolean;
+    
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'created_at'
+    })
+    created_at: Date;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'updated_at'
+    })
+    updated_at: Date;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'expires_at'
+    })
+    expires_at: Date;
+};

--- a/src/modules/message/message.model.ts
+++ b/src/modules/message/message.model.ts
@@ -1,0 +1,55 @@
+import { Model } from "sequelize";
+import { Column, DataType, Table } from "sequelize-typescript";
+
+@Table({ tableName: 'message' })
+export class Message extends Model<Message> {
+    @Column({
+        autoIncrement: true,
+        primaryKey: true
+    })
+    id: number;
+
+    @Column({
+        type: DataType.NUMBER,
+        allowNull: false,
+        field: 'sender_id'
+    })
+    sender_id: number;
+
+    @Column({
+        type: DataType.NUMBER,
+        allowNull: false,
+        field: 'receiver_id'
+    })
+    receiver_id: number;
+
+    @Column({
+        type: DataType.NUMBER,
+        allowNull: false,
+        field: 'job_id'
+    })
+    job_id: number;
+
+    @Column({
+        type: DataType.NUMBER,
+        allowNull: false,
+        field: 'content'
+    })
+    content: string;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'created_at'
+      })
+      createdAt: Date;
+    
+      @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        defaultValue: DataType.NOW,
+        field: 'updated_at'
+      })
+      updatedAt: Date;
+};


### PR DESCRIPTION
- Created `resetToken.model.ts` to define the ResetToken model with fields for `id`, `user_id`, `is_revoked`, `created_at`, `updated_at`, and `expires_at`.
- Added a migration file `20240524083123-create-resetToken-table.js` to create the `reset_token` table in the database, reflecting the fields defined in the model.